### PR TITLE
Include list header to appease g++-12

### DIFF
--- a/clustering/azp.cpp
+++ b/clustering/azp.cpp
@@ -2,6 +2,7 @@
 #include <queue>
 #include <iterator>
 #include <stack>
+#include <list>
 
 #include "../DataUtils.h"
 #include "azp.h"


### PR DESCRIPTION
While testing an upgrade of package `BH` against all its reverse-dependencies (see [this issue] (https://github.com/eddelbuettel/bh/issues/88) for details) I noticed that `rgeoda` failed to build.  

The cause is unrelated to the `BH` upgrade and due to the fact that I ran the tests with g++-12 (on Debian testing).  The newer compiler wants an explicit `#include` for the `std::list` data structure.  Once that one line is added the package installs and tests fine under `g++-12`.

I followed the git source via the submodule to this repo.  The change is very simple.  It would be lovely if you could update the package at CRAN even though this is more of a g++ issue than a BH issue (but 'eventually' CRAN will nag on this too).  I see that CRAN also nags on the `sprintf` issue [per this log](https://www.stats.ox.ac.uk/pub/bdr/M1mac/rgeoda.out) which should be easy to fix at the same time.
