### PR TITLE
fix: lint error in pam.cpp and limit positive number in nextInt()

### DIFF
--- a/clustering/pam.cpp
+++ b/clustering/pam.cpp
@@ -63,10 +63,10 @@ std::vector<int> BUILD::run(const std::vector<int>& ids, int k)
                 continue;
             }
             double sum = 0., v;
-            for (int k=0; k<nn; ++k) {
-                v = std::min(dist->getDistance(ids[j], ids[k]), mindist[ids[k]]);
+            for (int m=0; m<nn; ++m) {
+                v = std::min(dist->getDistance(ids[j], ids[m]), mindist[ids[m]]);
                 sum += v;
-                tempd[ ids[k] ]  =  v;
+                tempd[ ids[m] ]  =  v;
             }
             if(sum < best) {
                 best = sum;

--- a/rng.h
+++ b/rng.h
@@ -58,9 +58,8 @@ public:
     }
     int nextInt(int n) {
         if (n <=0) return 0;
-        int r =  (int)((n & -n) == n ? (nextLong() & n) - 1 // power of two
-                       : (unsigned long long)(((unsigned long long)nextLong() >> 32) * n) >> 32);
-        return r < 0 ? 0 : r;
+        int r =  (int)((((unsigned long long)nextLong() >> 32) * n) >> 32);
+        return r;
     }
 
     long long nextLong() {


### PR DESCRIPTION
Fix the `nextInt(int n)` function in Xoroshiro128Random RNG that behaves inconsistently on different platforms.

`n & -n == n` is a condition that is borrowed from Java language, which doesn't work here in the C++ code. So, the fix add a condition: `if (n <= 0) return 0` to only allow positive range when calling `nextInt()`.