### PR TITLE
fix: maxp crashes with more than 1 threads

### DIFF
--- a/clustering/azp.cpp
+++ b/clustering/azp.cpp
@@ -1186,7 +1186,7 @@ void MaxpRegion::PhaseConstructionThreaded()
             perror("Thread create failed.");
         }
     }
-    for (int j = 0; j < nCPUs; j++) {
+    for (int j = 0; j < tot_threads; j++) {
         pthread_join(threadPool[j], NULL);
     }
     delete[] args;
@@ -1242,7 +1242,7 @@ void MaxpRegion::PhaseLocalImprovementThreaded()
             perror("Thread create failed.");
         }
     }
-    for (int j = 0; j < nCPUs; j++) {
+    for (int j = 0; j < tot_threads; j++) {
         pthread_join(threadPool[j], NULL);
     }
     delete[] args;


### PR DESCRIPTION
The max-p functions run in parallel using threads. There is a bug that `pthread_join()` has been called on different numbers of threads that have been created via `pthread_create()` and stored in `threadPool[]`. 

In details, the `tot_threads` could be a smaller number than `nCPUs` which is setup by users vis `cpu_threads`, therefore the size of threadPool[] should be tot_threads instead of nCPUs.

Ref crashes in rgeoda:
https://github.com/GeoDaCenter/rgeoda/issues/39
https://github.com/GeoDaCenter/rgeoda/issues/38
https://github.com/GeoDaCenter/rgeoda/issues/33
https://github.com/GeoDaCenter/rgeoda/issues/27